### PR TITLE
Port RTL/MJIT to Windows MINGW.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -68,7 +68,7 @@ debugflags = @debugflags@
 warnflags = @warnflags@ @strict_warnflags@
 cppflags = @cppflags@
 XCFLAGS = @XCFLAGS@
-CPPFLAGS = @CPPFLAGS@ $(INCFLAGS) -DBUILD_DIR=\""$(PWD)"\" -DDEST_INCDIR=\""$(prefix)/include/$(RUBY_BASE_NAME)-$(ruby_version)/$(arch)"\"
+CPPFLAGS = @CPPFLAGS@ $(INCFLAGS) -DDEST_INCDIR=\""include/$(RUBY_BASE_NAME)-$(ruby_version)/$(arch)"\" -DLIBRUBYARG_SHARED=\""$(LIBRUBYARG_SHARED)"\"
 LDFLAGS = @STATIC@ $(CFLAGS) @LDFLAGS@
 EXTLDFLAGS = @EXTLDFLAGS@
 XLDFLAGS = @XLDFLAGS@ $(EXTLDFLAGS)

--- a/common.mk
+++ b/common.mk
@@ -879,7 +879,7 @@ rb_mjit_header.h: PHONY probes.h
 	
 rb_mjit_min_header-$(RUBY_PROGRAM_VERSION).h: rb_mjit_header.h $(srcdir)/MJIT_KEEP $(srcdir)/tool/mjit_header.rb $(srcdir)/tool/minimize_mjit_header.rb
 	@$(ECHO) building $@
-	$(Q)$(exec) egrep -v '^#|^$$' rb_mjit_header.h | $(BASERUBY) -I$(srcdir)/tool $(srcdir)/tool/minimize_mjit_header.rb $(CC) $(srcdir)/MJIT_KEEP > $@.new && mv $@.new $@
+	$(Q)$(exec) egrep -v '^#[^p]|^$$' rb_mjit_header.h | $(BASERUBY) -I$(srcdir)/tool $(srcdir)/tool/minimize_mjit_header.rb $(CC) $(srcdir)/MJIT_KEEP > $@.new && mv $@.new $@
 
 rb_mjit_import.h: rb_mjit_min_header-$(RUBY_PROGRAM_VERSION).h $(srcdir)/tool/mjit_header.rb $(srcdir)/tool/extract_mjit_header_externs.rb
 	$(Q)$(exec) cat $< | $(BASERUBY) -I$(srcdir)/tool $(srcdir)/tool/extract_mjit_header_externs.rb > $@.new && mv $@.new $@

--- a/compile.c
+++ b/compile.c
@@ -198,7 +198,7 @@ r_value(VALUE value)
 #define USE_SELF_LD 0
 
 /* Different macros to convert to/from lindex_t.  */
-#define INT2LINT(x) ((long) (x))
+#define INT2LINT(x) ((ssize_t) (x))
 #define LINT2INT(x) ((int) (x))
 #define FIXNUM2LINT(x) ((int) (x))
 

--- a/rtl_exec.c
+++ b/rtl_exec.c
@@ -550,7 +550,7 @@ iseq2var_f(rb_control_frame_t *cfp, VALUE *res, rindex_t res_ind, ISEQ iseq)
    frame CFP to an upper level local variable with index IDX in a
    frame with LEVEL (0 is CFP).  */
 static do_inline void
-var2uploc_f(rb_control_frame_t *cfp, rb_num_t idx, VALUE *from, rb_num_t level)
+var2uploc_f(rb_control_frame_t *cfp, sindex_t idx, VALUE *from, rb_num_t level)
 {
     VALUE *ep = cfp->ep;
     int i, lev = (int)level;
@@ -563,7 +563,7 @@ var2uploc_f(rb_control_frame_t *cfp, rb_num_t idx, VALUE *from, rb_num_t level)
 /* Assign value VAL to an upper level local variable with index IDX in
    a frame with LEVEL (0 is CFP).  */
 static do_inline void
-val2uploc_f(rb_control_frame_t *cfp, rb_num_t idx, VALUE val, rb_num_t level)
+val2uploc_f(rb_control_frame_t *cfp, sindex_t idx, VALUE val, rb_num_t level)
 {
     VALUE *ep = cfp->ep;
     int i, lev = (int)level;
@@ -577,7 +577,7 @@ val2uploc_f(rb_control_frame_t *cfp, rb_num_t idx, VALUE val, rb_num_t level)
    local variable with index IDX in previous frame and return from the
    current frame.  */
 static do_inline void
-ret_to_loc_f(rb_thread_t *th, rb_control_frame_t *cfp, rb_num_t idx, VALUE *from)
+ret_to_loc_f(rb_thread_t *th, rb_control_frame_t *cfp, sindex_t idx, VALUE *from)
 {
     rb_control_frame_t *reg_cfp = cfp; /* for GET_EP, GET_CFP */
     VALUE *ep = cfp->ep;
@@ -592,7 +592,7 @@ ret_to_loc_f(rb_thread_t *th, rb_control_frame_t *cfp, rb_num_t idx, VALUE *from
 /* Analogous to ret_to_local_f but assign the value to a temporary
    variable.  */
 static do_inline void
-ret_to_temp_f(rb_thread_t *th, rb_control_frame_t *cfp, rb_num_t idx, VALUE *from)
+ret_to_temp_f(rb_thread_t *th, rb_control_frame_t *cfp, sindex_t idx, VALUE *from)
 {
     rb_control_frame_t *reg_cfp = cfp; /* for GET_EP, GET_CFP */
     rb_control_frame_t *prev_cfp = RUBY_VM_PREVIOUS_CONTROL_FRAME(cfp);

--- a/ruby.c
+++ b/ruby.c
@@ -1544,9 +1544,6 @@ process_options(int argc, char **argv, ruby_cmdline_options_t *opt)
 	    opt->intern.enc.name = int_enc_name;
     }
 
-    if (opt->mjit.on)
-      mjit_init(&opt->mjit);
-    
     if (opt->src.enc.name)
 	rb_warning("-K is specified; it is for 1.8 compatibility and may cause odd behavior");
 
@@ -1599,6 +1596,10 @@ process_options(int argc, char **argv, ruby_cmdline_options_t *opt)
 
     ruby_gc_set_params(opt->safe_level);
     ruby_init_loadpath_safe(opt->safe_level);
+
+    if (opt->mjit.on)
+      mjit_init(&opt->mjit);
+
     Init_enc();
     lenc = rb_locale_encoding();
     rb_enc_associate(rb_progname, lenc);

--- a/tool/minimize_mjit_header.rb
+++ b/tool/minimize_mjit_header.rb
@@ -63,7 +63,7 @@ def check_code(cc, cflags, tfname, prefix)
   File.open(tfname, "w") do |test|
     test.puts $code
   end
-  if !system("#{cc} #{cflags} #{tfname} 2>/dev/null")
+  if !system("#{cc} #{cflags} #{tfname} 2>#{File::NULL}")
     STDERR.puts "error in #{prefix} header file:"
     STDERR.puts " Try '#{cc} #{cflags} #{tfname}'"
     exit 1
@@ -97,7 +97,6 @@ cflags = "-S -DMJIT_HEADER -fsyntax-only -Werror=implicit-function-declaration -
 
 # Check initial file correctness
 check_code(cc, cflags, tfname, "initial")
-
 while true
   pos_range = 0..-1
   n = factor # We try to remove N decls at once to speed up the process
@@ -116,7 +115,7 @@ while true
       end
     end
     before = all_decls_num / dot_factor
-    if keep_p || !system("#{cc} #{cflags} #{tfname} 2>/dev/null")
+    if keep_p || !system("#{cc} #{cflags} #{tfname} 2>#{File::NULL}")
       if n != 1
         n /= factor; # Fail: decrease searched decls number
       else

--- a/vm.c
+++ b/vm.c
@@ -126,7 +126,7 @@ vm_ep_in_heap_p_(const rb_thread_t *th, const VALUE *ep)
     }
 }
 
-static inline int
+inline int
 rb_vm_ep_in_heap_p(const VALUE *ep)
 {
     return vm_ep_in_heap_p_(GET_THREAD(), ep);

--- a/vm_core.h
+++ b/vm_core.h
@@ -148,7 +148,7 @@
 #endif /* OPT_CALL_THREADED_CODE */
 
 typedef unsigned long rb_num_t;
-typedef unsigned long lindex_t;
+typedef size_t lindex_t;
 
 enum ruby_tag_type {
     RUBY_TAG_RETURN	= 0x1,

--- a/win32/mkexports.rb
+++ b/win32/mkexports.rb
@@ -7,7 +7,7 @@ module RbConfig
 end
 
 class Exports
-  PrivateNames = /(?:Init_|ruby_static_id_|.*_threadptr_|DllMain\b)/
+  PrivateNames = /(?:Init_|ruby_static_id_|DllMain\b)/
 
   @@subclass = []
   def self.inherited(klass)


### PR DESCRIPTION
Thank you for working on ruby's performance! I really like the way you wrote the code. As a proof of concept I did a Windows port of your invention. See the commit message for description of all single changes.

I tested with gcc on x86_64 only. RTL works per miniruby.exe and per ruby.exe. MJIT doesn't work per miniruby, because miniruby is static linked, but the MJIT binaries are linked to the external ruby DLL - not the miniruby-internal symbols. However MJIT works per ruby.exe, since it's linked to the one and the same ruby DLL. It passes the `make check` equally to the non RTL/MJIT version.

The compiler currently outputs a lot of warnings on Windows. I didn't try to resolve these for now, because there is a fundamental issue to be solved first: "long" is 32 bit only on Windows. The long type is used a lot in the RTL and MJIT code for instance as offsets to pointers. Interestingly enough *unsigned* long is used as positive and *negative* offset per typedef `lindex_t`. But adding a 32 bit negative offset to a 64 bit pointer is very different to adding 64 offset to 64 pointer.

I think there are two alternatives:

1. Use a 64 bit type as `lindex_t`: This is what I used in the attached pull request. This has the advantage, that all arithmetic operations with this type are the same on all supported platforms. However there seems to be no cross platform printf placeholder for 64 bit integers other then PRIdVALUE and co.

2. Use platform specific long size as `lindex_t`: This is how `lindex_t` was defined before my patch and how "long" is used in conjunction with FIXNUM in MRI. printf() can be used with simple `%l` in this case. The downside is, that it limits possible sizes of offsets, although there is no need to do so at runtime. It also makes arithmetic operations platform specific, so that additional type casts are required.

When the "long" type issue is solved, it makes sense to fix the compiler warnings.

Another portability issue is the use of pthread. While it is available on Windows MINGW, it is not on Visual-C. Possibly this can be solved by using ruby's cross platform rb_thread* functions. Since pthread works flawlessly on MINGW, I didn't change anything for now.

The minimizer task of rb_mjit_header is awfully slow. This is due to the slow process starts on Windows. This task runs almost 10 times slower compared to Linux. It's even worse with activated virus scanning. The algorithm is quite efficient, but since each call to gcc yields to only one single bit of result, it requires roughly 2000 such calls. I think the longer term solution could be a pure ruby minimizer, instead of relying on the gcc parser.
