### PR TITLE
Use editable compiler options for MJIT calls

### DIFF
--- a/mjit.c
+++ b/mjit.c
@@ -565,25 +565,25 @@ CRITICAL_SECTION_FINISH(int level, const char *msg) {
 
    XXX_USE_PCH_ARAGS define additional options to use the precomiled
    header.  */
-static const char *GCC_COMMON_ARGS_DEBUG[] = {"gcc", "-O0", "-g", "-Wfatal-errors", "-fPIC", "-shared", "-w", "-pipe", "-nostartfiles", "-nodefaultlibs", "-nostdlib", NULL};
-static const char *GCC_COMMON_ARGS[] = {"gcc", "-O2", "-Wfatal-errors", "-fPIC", "-shared", "-w", "-pipe", "-nostartfiles", "-nodefaultlibs", "-nostdlib", NULL};
-static const char *GCC_USE_PCH_ARGS[] = {"-I/tmp", NULL};
-static const char *GCC_EMIT_PCH_ARGS[] = {NULL};
+	static const char *GCC_COMMON_ARGS_DEBUG[] = {"gcc", "-O0", "-g", "-Wfatal-errors", "-fPIC", "-shared", "-w", "-pipe", "-nostartfiles", "-nodefaultlibs", "-nostdlib", NULL};
+	static const char *GCC_COMMON_ARGS[] = {"gcc", "-O2", "-Wfatal-errors", "-fPIC", "-shared", "-w", "-pipe", "-nostartfiles", "-nodefaultlibs", "-nostdlib", NULL};
+	static const char *GCC_USE_PCH_ARGS[] = {"-I/tmp", NULL};
+	static const char *GCC_EMIT_PCH_ARGS[] = {NULL};
 
-#ifdef __MACH__
+	#ifdef __MACH__
 
-static const char *LLVM_COMMON_ARGS_DEBUG[] = {"clang", "-O0", "-g", "-dynamic", "-I/usr/local/include", "-L/usr/local/lib", "-w", "-bundle", NULL};
-static const char *LLVM_COMMON_ARGS[] = {"clang", "-O2", "-dynamic", "-I/usr/local/include", "-L/usr/local/lib", "-w", "-bundle", NULL};
+	static const char *LLVM_COMMON_ARGS_DEBUG[] = {"clang", "-O0", "-g", "-dynamic", "-I/usr/local/include", "-L/usr/local/lib", "-w", "-bundle", NULL};
+	static const char *LLVM_COMMON_ARGS[] = {"clang", "-O2", "-dynamic", "-I/usr/local/include", "-L/usr/local/lib", "-w", "-bundle", NULL};
 
-#else
+	#else
 
-static const char *LLVM_COMMON_ARGS_DEBUG[] = {"clang", "-O0", "-g", "-fPIC", "-shared", "-I/usr/local/include", "-L/usr/local/lib", "-w", "-bundle", NULL};
-static const char *LLVM_COMMON_ARGS[] = {"clang", "-O2", "-fPIC", "-shared", "-I/usr/local/include", "-L/usr/local/lib", "-w", "-bundle", NULL};
+	static const char *LLVM_COMMON_ARGS_DEBUG[] = {"clang", "-O0", "-g", "-fPIC", "-shared", "-I/usr/local/include", "-L/usr/local/lib", "-w", "-bundle", NULL};
+	static const char *LLVM_COMMON_ARGS[] = {"clang", "-O2", "-fPIC", "-shared", "-I/usr/local/include", "-L/usr/local/lib", "-w", "-bundle", NULL};
 
-#endif /* #if __MACH__ */
+	#endif /* #if __MACH__ */
 
-static const char *LLVM_USE_PCH_ARGS[] = {"-include-pch", NULL, "-Wl,-undefined", "-Wl,dynamic_lookup", NULL};
-static const char *LLVM_EMIT_PCH_ARGS[] = {"-emit-pch", NULL};
+	static const char *LLVM_USE_PCH_ARGS[] = {"-include-pch", NULL, "-Wl,-undefined", "-Wl,dynamic_lookup", NULL};
+	static const char *LLVM_EMIT_PCH_ARGS[] = {"-emit-pch", NULL};
 
 /* All or most code for execution of any byte code insn is contained
    in the corresponding C function (see rtl_exec.c).  The following


### PR DESCRIPTION
Compiler command lines are currently hardcoded into `mjit.c` as shown in the attached patch. This impedes that they are quite static, so that users can't modify compiler flags.

Maybe it makes sense to allow user defined JIT compiler flags. I'm thinking of one of these:

1. Add ruby option(s) to inject CC, CFLAGS, LDFLAGS etc. into the MJIT compiler call.
2. Add ruby option(s) to set compiler command line arguments with placeholders, which are replaced by MJIT when called.
3. Use a INI or YAML like config file, which holds command line arguments with placeholders.
4. Use a ruby based config file, which holds command line arguments with placeholders.
5. Use rbconfig for MJIT configuration.

A config file would have some advantages over command line arguments. It is more flexible, since it doesn't pre-define static parts of the call. It could be predefined throughout the build as clang/gcc and debug versions.

An INI file could be read very early in the startup process, but requires a separate parser. A ruby file parser is already builtin, but cannot be used before the prelude phase.

I like option 4 most, since MJIT has no useful impact at the startup phase of a program and it allows easy switching between debug/release and gcc/clang.


PS: The issue tracker is not enabled for this project, so that I misused this pull request. How should issues to RTL/MJIT being discussed?

PPS: Will you be at the Ruby World Conference in Matsue (given that you're nominated as well) so that we could meet in person?