### PR TITLE
Fix ivread to read ivar

### DIFF
--- a/MJIT-benchmarks/ivread.rb
+++ b/MJIT-benchmarks/ivread.rb
@@ -7,8 +7,7 @@ class C
   def l
     i = 0
     while i < 1000000
-      @a
-      i += 1
+      i += @a
     end
   end
 end


### PR DESCRIPTION
It found that `@a` is optimized away in ivread.rb and currently it's not benchmarking "ivread". Is it intentional?

## before
```
$ ruby -v
ruby 2.5.0p0 (2017-12-25 revision 61468) [x86_64-linux]
$ ruby --dump=insns MJIT-benchmarks/ivread.rb
(snip)
== disasm: #<ISeq:l@MJIT-benchmarks/ivread.rb:7 (7,2)-(13,5)>===========
== catch table
| catch type: break  st: 0009 ed: 0027 sp: 0000 cont: 0027
| catch type: next   st: 0009 ed: 0027 sp: 0000 cont: 0006
| catch type: redo   st: 0009 ed: 0027 sp: 0000 cont: 0009
|------------------------------------------------------------------------
local table (size: 1, argc: 0 [opts: 0, rest: -1, post: 0, block: -1, kw: -1@-1, kwrest: -1])
[ 1] i
0000 putobject_OP_INT2FIX_O_0_C_                                      (   8)[LiCa]
0001 setlocal_OP__WC__0 i
0003 jump             17                                              (   9)[Li]
0005 putnil
0006 pop
0007 jump             17
0009 getlocal_OP__WC__0 i                                             (  11)[Li]
0011 putobject_OP_INT2FIX_O_1_C_
0012 opt_plus         <callinfo!mid:+, argc:1, ARGS_SIMPLE>, <callcache>
0015 setlocal_OP__WC__0 i
0017 getlocal_OP__WC__0 i                                             (   9)
0019 putobject        1000000
0021 opt_lt           <callinfo!mid:<, argc:1, ARGS_SIMPLE>, <callcache>
0024 branchif         9
0026 putnil
0027 leave                                                            (  13)[Re]
```

## after
```
$ ruby -v
ruby 2.5.0p0 (2017-12-25 revision 61468) [x86_64-linux]
$ ruby --dump=insns MJIT-benchmarks/ivread.rb
(snip)
== disasm: #<ISeq:l@MJIT-benchmarks/ivread.rb:7 (7,2)-(12,5)>===========
== catch table
| catch type: break  st: 0009 ed: 0029 sp: 0000 cont: 0029
| catch type: next   st: 0009 ed: 0029 sp: 0000 cont: 0006
| catch type: redo   st: 0009 ed: 0029 sp: 0000 cont: 0009
|------------------------------------------------------------------------
local table (size: 1, argc: 0 [opts: 0, rest: -1, post: 0, block: -1, kw: -1@-1, kwrest: -1])
[ 1] i
0000 putobject_OP_INT2FIX_O_0_C_                                      (   8)[LiCa]
0001 setlocal_OP__WC__0 i
0003 jump             19                                              (   9)[Li]
0005 putnil
0006 pop
0007 jump             19
0009 getlocal_OP__WC__0 i                                             (  10)[Li]
0011 getinstancevariable :@a, <is:0>
0014 opt_plus         <callinfo!mid:+, argc:1, ARGS_SIMPLE>, <callcache>
0017 setlocal_OP__WC__0 i
0019 getlocal_OP__WC__0 i                                             (   9)
0021 putobject        1000000
0023 opt_lt           <callinfo!mid:<, argc:1, ARGS_SIMPLE>, <callcache>
0026 branchif         9
0028 putnil
0029 leave                                                            (  12)[Re]
```

Now it has `getinstancevariable :@a`.